### PR TITLE
deleted obsolete commented stuff

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,4 @@
 envlist = py25,py26,py27,pypy
 
 [testenv]
-deps=
-;	nose
-;	Flask-SQLAlchemy
-	Flask-Testing
-;	SQLAlchemy
-;	Werkzeug
-;	Whoosh
 commands=python setup.py test


### PR DESCRIPTION
You don't need Flask-Testing as a dependency in tox.ini if it's mentioned in setup.py file.
