### PR TITLE
update setup.py to be built in python 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     platforms='any',
     install_requires=[x.strip() for x in
         open(os.path.join(os.path.dirname(__file__),
-            'requirements.txt')).xreadlines()],
+            'requirements.txt'))],
     tests_require=['Flask-Testing'],
 
     classifiers=[


### PR DESCRIPTION
At this time pip does not install Flask-WhooshAlchemy.  In order to install from git using `python setup.py install`, xreadlines must be removed.
