### PR TITLE
Python 3.3 support

### DIFF
--- a/flask_whooshalchemy.py
+++ b/flask_whooshalchemy.py
@@ -36,6 +36,13 @@ __searchable__ = '__searchable__'
 
 DEFAULT_WHOOSH_INDEX_NAME = 'whoosh_index'
 
+# Adding Python 3.3 support
+try:
+    unicode
+except NameError:
+    unicode = str
+
+
 
 class _QueryProxy(flask_sqlalchemy.BaseQuery):
     # We're replacing the model's ``query`` field with this proxy. The main
@@ -236,7 +243,7 @@ def _after_flush(app, changes):
             bytype.setdefault(change[0].__class__.__name__, []).append((update,
                 change[0]))
 
-    for model, values in bytype.iteritems():
+    for model, values in bytype.items():
         index = whoosh_index(app, values[0][1].__class__)
         with index.writer() as writer:
             primary_field = values[0][1].pure_whoosh.primary_key_name

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -79,7 +79,7 @@ class Tests(TestCase):
     def tearDown(self):
         try:
             shutil.rmtree(self.app.config['WHOOSH_BASE'])
-        except OSError, e:
+        except OSError as e:
             if e.errno != 2:  # code 2 - no such file or directory
                 raise
 
@@ -125,6 +125,7 @@ class Tests(TestCase):
 
         db.session.add(ObjectC(title=u'my title', content=u'hello world'))
         self.assertRaises(AttributeError, db.session.commit)
+        db.session.close()  # TODO: The test fails without it, check [Fedorof]
         db.session.rollback()
 
 


### PR DESCRIPTION
A couple of small changes allow using the extention with Python 3.3 and higher.
I also updated a test (see line 128 in test_all.py) - it failed on both Python 2.7 and Python 3.3. 
