### PR TITLE
Feature implementation: Custom analyzers

### DIFF
--- a/flask_whooshalchemy.py
+++ b/flask_whooshalchemy.py
@@ -206,6 +206,7 @@ def _get_whoosh_schema_and_primary_key(model):
     schema = {}
     primary = None
     searchable = set(model.__searchable__)
+    analyzer = getattr(model, "__analyzer__", StemmingAnalyzer())
     for field in model.__table__.columns:
         if field.primary_key:
             schema[field.name] = whoosh.fields.ID(stored=True, unique=True)
@@ -216,7 +217,7 @@ def _get_whoosh_schema_and_primary_key(model):
                     sqlalchemy.types.Unicode)):
 
             schema[field.name] = whoosh.fields.TEXT(
-                    analyzer=StemmingAnalyzer())
+                    analyzer=analyzer)
 
     return Schema(**schema), primary
 


### PR DESCRIPTION
Aloha!

I working on a project which required a `Metaphone` filter added to the fulltext search due to the average spelling mistakes, so I thought I would implement it in an style which fits closely with the module in hand.

```python
from whoosh.analysis import StemmingAnalyzer, DoubleMetaphoneFilter

class Table(db.Model): 
    __tablename__ = "test"
    __searchable__ = ["field1", "field2"]
    __analyzer__ = StemmingAnalyzer() | DoubleMetaphoneFilter()
```

The logic behind this, albeit basic, is using the inbuilt `getattr` for a fallback to the standard `StemmingAnalyzer` which you have defaulted everything to.

I understand that PR #17 has already implemented a solution to this, but this should give a more systemic approach to users utilizing the library and give them the ability to add custom analyzers for different tables being indexed by Whoosh.