### PR TITLE
Obey result sorting if caller explicitly uses order_by() on query

### DIFF
--- a/flask_whooshalchemy.py
+++ b/flask_whooshalchemy.py
@@ -58,8 +58,10 @@ class _QueryProxy(flask_sqlalchemy.BaseQuery):
 
         super_iter = super(_QueryProxy, self).__iter__()
 
-        if self._whoosh_rank is None:
-            # Whoosh search hasn't been run so behave as normal.
+        if self._whoosh_rank is None or self._order_by is not False:
+            # Whoosh search hasn't been run or caller has explicitly asked
+            # for results to be sorted, so behave as normal (no Whoosh
+            # relevance score sorting).
 
             return super_iter
 


### PR DESCRIPTION
When calling .query.whoosh_search(), sometimes I want order my results by a certain column and _not_ the Whoosh rank of the record.

For example, I want to allow users to search by product name but ultimately order the results my alphanumeric product code.

The former behaviour of Flask-WhooshAlchemy is to silently ignore the order_by clause. The proposed new behaviour is to obey the order_by clause when the user has specified it on the query.
