### PR TITLE
Explicitly declare 'null'

### DIFF
--- a/flask_whooshalchemy.py
+++ b/flask_whooshalchemy.py
@@ -116,7 +116,7 @@ class _QueryProxy(flask_sqlalchemy.BaseQuery):
             # be a query.
 
             # XXX is this efficient?
-            return self.filter('null')
+            return self.filter(sqlalchemy.text('null'))
 
         result_set = set()
         result_ranks = {}


### PR DESCRIPTION
Prevents "SAWarning: Textual SQL expression 'null' should be explicitly declared as text('null') (this warning may be suppressed after 10 occurrences)
  {"expr": util.ellipses_string(element)})"